### PR TITLE
fix: go-version in GitHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: '1.20'
       - uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
@@ -35,9 +35,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: '1.20'
       - uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: "1.20"
       - uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: "1.20"
       - uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod


### PR DESCRIPTION
## Why

Somehow, the CI is trying to install `1.2` version 👉 Ref: https://github.com/kekwork/terraform-provider-ip/actions/runs/5356145077/jobs/9715297825


## Ref

Note: https://github.com/actions/setup-go

> Due to the peculiarities of YAML parsing, it is recommended to wrap the version in single quotation marks:
